### PR TITLE
Implement visual errors to make the bot more user-friendly

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -485,18 +485,18 @@ async def help(ctx):
     hembed = discord.Embed(title="Yagoo Bot Commands")
     hembed.description = "Currently the bot only has a small number of commands, as it is still in development!\n" \
                          "New stream notifications will be posted on a 3 minute interval, thus any new notifications " \
-                         "will not come immediately after subscribing."
+                         "will not come immediately after subscribing.\n" \
+                         "Currently all the commands require the user to have either the `Administrator` or `Manage Webhook` permission in the channel or server."
     
     hembed.add_field(name="Commands",
                      value="**y!sub** (Alias: subscribe)\n"
-                           "Brings up a list of channels to subscribe to.\n"
-                           "[Requires user to have `Administrator` or `Manage Webhook` perms]\n\n"
+                           "Brings up a list of channels to subscribe to.\n\n"
                            "**y!unsub** (Alias: unsubscribe)\n"
-                           "Brings up a list of channels to unsubscribe to.\n"
-                           "[Requires user to have `Administrator` or `Manage Webhook` perms]\n\n"
+                           "Brings up a list of channels to unsubscribe to.\n\n"
                            "**y!sublist** (Alias: subs, subslist)\n"
-                           "Brings up a list of channels that the current chat channel has subscribed to.\n"
-                           "[Requires user to have `Administrator` or `Manage Webhook` perms]\n\n")
+                           "Brings up a list of channels that the current chat channel has subscribed to.\n\n"
+                           "**y!subdefault** (Alias: subDefault)\n"
+                           "Set's the default subscription type for the channel.")
 
     await ctx.send(embed=hembed)
 

--- a/bot.py
+++ b/bot.py
@@ -153,7 +153,7 @@ async def getSubType(ctx, mode, prompt = None):
                 await msg.delete()
 
 async def botError(ctx, error):
-    errEmbed = discord.Embed(title="An error has occurred!")
+    errEmbed = discord.Embed(title="An error has occurred!", color=discord.Colour.red())
     if "403 Forbidden" in str(error):
         permData = [{
             "formatName": "Manage Webhooks",

--- a/bot.py
+++ b/bot.py
@@ -179,7 +179,7 @@ async def botError(ctx, error):
         return errEmbed
     elif isinstance(error, commands.CheckFailure):
         errEmbed.description = "You are missing permissions to use this bot.\n" \
-                               "Ensure that either you have these permissions for the channel/server:\n" \
+                               "Ensure that you have one of these permissions for the channel/server:\n\n" \
                                " - `Administrator (Server)`\n - `Manage Webhooks (Channel/Server)`"
         
         return errEmbed

--- a/bot.py
+++ b/bot.py
@@ -152,6 +152,32 @@ async def getSubType(ctx, mode, prompt = None):
             else:
                 await msg.delete()
 
+async def botError(ctx, error):
+    errEmbed = discord.Embed(title="An error has occurred!")
+    if "403 Forbidden" in str(error):
+        permData = [{
+            "formatName": "Manage Webhooks",
+            "dataName": "manage_webhooks"
+        }, {
+            "formatName": "Manage Messages",
+            "dataName": "manage_messages"
+        }]
+        permOutput = []
+        for perm in iter(ctx.guild.me.permissions_in(ctx.channel)):
+            for pCheck in permData:
+                if perm[0] == pCheck["dataName"]:
+                    if not perm[1]:
+                        permOutput.append(pCheck["formatName"])
+        plural = "this permission"
+        if len(permOutput) > 1:
+            plural = "these permissions"
+        errEmbed.description = "This bot has insufficient permissions for this channel.\n" \
+                               f"Please allow the bot {plural}:\n"
+        for perm in permOutput:
+            errEmbed.description += f'\n - `{perm}`'
+        
+        return errEmbed
+
 async def genServer(servers, cserver, cchannel):
     if str(cserver.id) not in servers:
         logging.debug("New server! Adding to database.")

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,4 @@
-import aiohttp, discord, asyncio, json, yaml, logging, sys, imgkit, os, pytz
+import aiohttp, discord, asyncio, json, yaml, logging, sys, imgkit, os, pytz, traceback
 from datetime import datetime
 from discord.ext.commands.core import command
 from itertools import islice
@@ -177,6 +177,10 @@ async def botError(ctx, error):
             errEmbed.description += f'\n - `{perm}`'
         
         return errEmbed
+    else:
+        print("An unknown error has occurred.")
+        traceback.print_tb(error.__traceback__)
+        print(error)
 
 async def genServer(servers, cserver, cchannel):
     if str(cserver.id) not in servers:

--- a/bot.py
+++ b/bot.py
@@ -505,6 +505,12 @@ async def help(ctx):
 async def subDefault(ctx):
     await getSubType(ctx, 1)
 
+@subDefault.error
+async def subdef_error(ctx, error):
+    errEmbed = await botError(ctx, error)
+    if errEmbed:
+        await ctx.send(embed=errEmbed)
+
 # TODO: Error on missing perms (Manage Webhooks and Manage Messages) here
 @bot.command(aliases=['sub'])
 @commands.check(subPerms)

--- a/bot.py
+++ b/bot.py
@@ -640,6 +640,12 @@ async def subscribe(ctx):
                 else:
                     await msg.delete()
 
+@subscribe.error
+async def sub_error(ctx, error):
+    errEmbed = await botError(ctx, error)
+    if errEmbed:
+        await ctx.send(embed=errEmbed)
+
 # TODO: Error on missing perms (Manage Webhooks and Manage Messages) here
 @bot.command(aliases=["unsub"])
 @commands.check(subPerms)
@@ -785,6 +791,12 @@ async def unsubscribe(ctx):
                 else:
                     await msg.delete()
 
+@unsubscribe.error
+async def unsub_error(ctx, error):
+    errEmbed = await botError(ctx, error)
+    if errEmbed:
+        await ctx.send(embed=errEmbed)
+
 # TODO: Error on missing perms (Manage Messages) here
 @bot.command(aliases=["subs", "subslist", "subscriptions", "subscribed"])
 @commands.check(subPerms)
@@ -891,6 +903,12 @@ async def sublist(ctx):
                         break
                 else:
                     await msg.delete()
+
+@sublist.error
+async def sublist_error(ctx, error):
+    errEmbed = await botError(ctx, error)
+    if errEmbed:
+        await ctx.send(embed=errEmbed)
 
 @bot.command()
 @commands.check(creatorCheck)

--- a/bot.py
+++ b/bot.py
@@ -177,6 +177,12 @@ async def botError(ctx, error):
             errEmbed.description += f'\n - `{perm}`'
         
         return errEmbed
+    elif isinstance(error, commands.CheckFailure):
+        errEmbed.description = "You are missing permissions to use this bot.\n" \
+                               "Ensure that either you have these permissions for the channel/server:\n" \
+                               " - `Administrator (Server)`\n - `Manage Webhooks (Channel/Server)`"
+        
+        return errEmbed
     else:
         print("An unknown error has occurred.")
         traceback.print_tb(error.__traceback__)


### PR DESCRIPTION
Currently, all the errors encountered by the bot are only output to the terminal. This only lets the person hosting know about the bot encountering an error.
Since people can disallow certain permissions when inviting the bot, this can cause the mainly used commands to fail with permissions such as `Manage Webhooks` disabled for the bot.
To make sure that users know that the bot isn't broken, visual errors need to be implemented to tell the user what they are doing wrong.