### PR TITLE
Fix the bot soft-locking if the thumbnail server errors out silently

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,3 @@
-from typing import KeysView
 import aiohttp
 import discord
 import asyncio

--- a/bot.py
+++ b/bot.py
@@ -582,4 +582,13 @@ async def maintenance(ctx):
     logging.info("Logged out.")
     sys.exit()
 
+@bot.command(aliases=["gCount", "gcount", "guildcount"])
+@commands.check(creatorCheck)
+async def guildCount(ctx):
+    totalGuilds = 0
+    for x in bot.guilds:
+        totalGuilds += 1
+    
+    await ctx.send(f"Yagoo bot is now live in {totalGuilds} servers!")
+
 bot.run(settings["token"])

--- a/bot.py
+++ b/bot.py
@@ -28,7 +28,10 @@ bot.remove_command('help')
 
 @bot.event
 async def on_ready():
-    print("Yagoo Bot now streaming!")
+    guildCount = 0
+    for guilds in bot.guilds:
+        guildCount += 1
+    print(f"Yagoo Bot now streaming in {guildCount} servers!")
     await bot.change_presence(status=discord.Status.online, activity=discord.Activity(type=discord.ActivityType.watching, name='other Hololive members'))
     if settings["notify"]:
         bot.add_cog(StreamCycle(bot))

--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ from discord.ext import commands
 from ext.infoscraper import channelInfo
 from ext.cogs.subCycle import StreamCycle, streamcheck
 from ext.cogs.msCycle import msCycle, milestoneNotify
+from ext.cogs.dblUpdate import guildUpdate
 from ext.share.botUtils import subPerms, chunks, creatorCheck
 from ext.share.dataGrab import getSubType, getwebhook
 from ext.share.prompts import botError, subCheck
@@ -36,6 +37,8 @@ async def on_ready():
         bot.add_cog(StreamCycle(bot))
     if settings["milestone"]:
         bot.add_cog(msCycle(bot))
+    if settings["dblPublish"]:
+        bot.add_cog(guildUpdate(bot, settings["dblToken"]))
 
 @bot.event
 async def on_guild_remove(server):

--- a/ext/cogs/dblUpdate.py
+++ b/ext/cogs/dblUpdate.py
@@ -1,0 +1,14 @@
+import dbl
+import logging
+from discord.ext import commands
+
+class guildUpdate(commands.Cog):
+    """Handles interactions with the top.gg API"""
+
+    def __init__(self, bot, token):
+        self.bot = bot
+        self.token = token
+        self.dblpy = dbl.DBLClient(self.bot, self.token, autopost=True) # Autopost will post your guild count every 30 minutes
+
+    async def on_guild_post():
+        logging.info("Discord Bot List - Server count posted successfully.")

--- a/ext/cogs/msCycle.py
+++ b/ext/cogs/msCycle.py
@@ -75,14 +75,17 @@ async def milestoneNotify(msDict, bot):
         logging.debug(f'Removed temporary HTML file')
         os.remove("milestone/msTemp.html")
         for server in servers:
-            logging.debug(f'Accessing server id {server}')
-            for dch in servers[server]:
-                logging.debug(f'Milestone - Channel Data: {servers[server][dch]["milestone"]}')
-                logging.debug(f'Milestone - Channel Check Pass: {channel in servers[server][dch]["milestone"]}')
-                if channel in servers[server][dch]["milestone"]:
-                    logging.debug(f'Posting to {dch}...')
-                    await bot.get_channel(int(dch)).send(f'{msDict[channel]["name"]} has reached {msDict[channel]["msText"].replace("Subscribers", "subscribers")}!', file=discord.File(f'milestone/generated/{channel}.png'))
-                    await bot.get_channel(int(dch)).send("おめでとう！")
+            try:
+                logging.debug(f'Accessing server id {server}')
+                for dch in servers[server]:
+                    logging.debug(f'Milestone - Channel Data: {servers[server][dch]["milestone"]}')
+                    logging.debug(f'Milestone - Channel Check Pass: {channel in servers[server][dch]["milestone"]}')
+                    if channel in servers[server][dch]["milestone"]:
+                        logging.debug(f'Posting to {dch}...')
+                        await bot.get_channel(int(dch)).send(f'{msDict[channel]["name"]} has reached {msDict[channel]["msText"].replace("Subscribers", "subscribers")}!', file=discord.File(f'milestone/generated/{channel}.png'))
+                        await bot.get_channel(int(dch)).send("おめでとう！")
+            except Exception as e:
+                logging.error("Milestone - Failed to post on a server/channel!", exc_info=True)
 
 class msCycle(commands.Cog):
     def __init__(self, bot):

--- a/ext/cogs/subCycle.py
+++ b/ext/cogs/subCycle.py
@@ -38,21 +38,26 @@ async def streamcheck(ctx = None, test: bool = False, loop: bool = False):
                             logging.debug("Stream - Sending upload command to thumbnail server...")
                             upload = asyncUpl(channel, f'https://img.youtube.com/vi/{status["videoId"]}/maxresdefault_live.jpg')
                             uplSuccess = False
-
+                            
+                            timeout = 0
                             while True:
                                 if upload.ready and not upload.error:
                                     logging.debug("Stream - Uploaded thumbnail!")
                                     uplSuccess = True
                                     break
-                                elif upload.error:
+                                elif upload.error or timeout > 9:
                                     break
-
+                                
+                                timeout += 1
                                 await asyncio.sleep(0.5)
 
                             if not uplSuccess:
-                                logging.error("Stream - Couldn't upload thumbnail!")
+                                if timeout > 9:
+                                    logging.error("Stream - Server didn't return a thumbnail in time! Retrying in next cycle.")
+                                else:
+                                    logging.error("Stream - Couldn't upload thumbnail!")
                                 logging.error(upload.value)
-                                return
+                                break
                             
                             cstreams[channel] = {
                                 "name": ytchannel["name"],

--- a/ext/cogs/subCycle.py
+++ b/ext/cogs/subCycle.py
@@ -100,7 +100,7 @@ async def streamcheck(ctx = None, test: bool = False, loop: bool = False):
                 if x == 2:
                     logging.error("An error has occured!", exc_info=True)
                     print("An error has occurred.")
-                    traceback.print_tb(e)
+                    traceback.print_tb(e.__traceback__)
                     if len(stext) + len(f'{channel}: <:warning:786380003306111018>\n') <= 2000:
                         stext += f'{channel}: <:warning:786380003306111018>\n'
                     else:
@@ -119,14 +119,18 @@ async def streamNotify(bot, cData):
                         "videoId": ""
                     }
                 if ytch in servers[server][channel]["livestream"] and cData[ytch]["videoId"] != servers[server][channel]["notified"][ytch]["videoId"]:
-                    whurl = await getwebhook(bot, servers, server, channel)
-                    async with aiohttp.ClientSession() as session:
-                        embed = discord.Embed(title=f'{cData[ytch]["videoTitle"]}', url=f'https://youtube.com/watch?v={cData[ytch]["videoId"]}')
-                        embed.description = f'Started streaming {cData[ytch]["timeText"]}'
-                        embed.set_image(url=cData[ytch]["thumbURL"])
-                        webhook = Webhook.from_url(whurl, adapter=AsyncWebhookAdapter(session))
-                        await webhook.send(f'New livestream from {cData[ytch]["name"]}!', embed=embed, username=cData[ytch]["name"], avatar_url=cData[ytch]["image"])
-                        servers[server][channel]["notified"][ytch]["videoId"] = cData[ytch]["videoId"]
+                    try:
+                        whurl = await getwebhook(bot, servers, server, channel)
+                        async with aiohttp.ClientSession() as session:
+                            embed = discord.Embed(title=f'{cData[ytch]["videoTitle"]}', url=f'https://youtube.com/watch?v={cData[ytch]["videoId"]}')
+                            embed.description = f'Started streaming {cData[ytch]["timeText"]}'
+                            embed.set_image(url=cData[ytch]["thumbURL"])
+                            webhook = Webhook.from_url(whurl, adapter=AsyncWebhookAdapter(session))
+                            await webhook.send(f'New livestream from {cData[ytch]["name"]}!', embed=embed, username=cData[ytch]["name"], avatar_url=cData[ytch]["image"])
+                    except Exception as e:
+                        logging.error(f"Stream - An error has occurred while publishing stream notification to {channel}!", exc_info=True)
+                        break
+                    servers[server][channel]["notified"][ytch]["videoId"] = cData[ytch]["videoId"]
     with open("data/servers.json", "w", encoding="utf-8") as f:
         servers = json.dump(servers, f, indent=4)
 

--- a/ext/cogs/subCycle.py
+++ b/ext/cogs/subCycle.py
@@ -17,9 +17,9 @@ async def streamcheck(ctx = None, test: bool = False, loop: bool = False):
         channels = json.load(f)
     with open("data/settings.yaml") as f:
         settings = yaml.load(f, Loader=yaml.SafeLoader)
-    extServer = rpyc.connect(settings["thumbnailIP"], int(settings["thumbnailPort"]))
-    asyncUpl = rpyc.async_(extServer.root.thumbGrab)
     if not test:
+        extServer = rpyc.connect(settings["thumbnailIP"], int(settings["thumbnailPort"]))
+        asyncUpl = rpyc.async_(extServer.root.thumbGrab)
         cstreams = {}
         for channel in channels:
             for x in range(2):
@@ -98,7 +98,7 @@ async def streamcheck(ctx = None, test: bool = False, loop: bool = False):
                 break
             except Exception as e:
                 if x == 2:
-                    logging.error("An error has occured!", exc_info=True)
+                    logging.error("An error has occurred!", exc_info=True)
                     print("An error has occurred.")
                     traceback.print_tb(e.__traceback__)
                     if len(stext) + len(f'{channel}: <:warning:786380003306111018>\n') <= 2000:

--- a/ext/infoscraper.py
+++ b/ext/infoscraper.py
@@ -39,10 +39,7 @@ async def streamInfo(channelId: Union[str, int]):
                                     morevInfo = ytdata["contents"]["twoColumnWatchNextResults"]["results"]["results"]["contents"][0]["videoPrimaryInfoRenderer"]
                                     if "viewCount" in morevInfo:
                                         videoInfo = morevInfo["viewCount"]["videoViewCountRenderer"]
-                                        vcText = ""
-                                        for text in videoInfo["viewCount"]["runs"]:
-                                            vcText += text["text"]
-                                        if videoInfo["isLive"] and ("watching now" in vcText):
+                                        if videoInfo["isLive"] and ("Started streaming" in morevInfo["dateText"]["simpleText"]):
                                             title = ""
                                             if len(morevInfo["title"]["runs"]) > 1:
                                                 for subrun in morevInfo["title"]["runs"]:

--- a/ext/infoscraper.py
+++ b/ext/infoscraper.py
@@ -28,29 +28,30 @@ async def streamInfo(channelId: Union[str, int]):
                         with open(f"test/channels/{channelId}.json", "w", encoding="utf-8") as f:
                             json.dump(ytdata, f, indent=4)
                     if "contents" in ytdata:
-                        morevInfo = ytdata["contents"]["twoColumnWatchNextResults"]["results"]["results"]["contents"][0]["videoPrimaryInfoRenderer"]
-                        if "viewCount" in morevInfo:
-                            videoInfo = morevInfo["viewCount"]["videoViewCountRenderer"]
-                            vcText = ""
-                            for text in videoInfo["viewCount"]["runs"]:
-                                vcText += text["text"]
-                            if videoInfo["isLive"] and ("watching now" in vcText):
-                                title = ""
-                                if len(morevInfo["title"]["runs"]) > 1:
-                                    for subrun in morevInfo["title"]["runs"]:
-                                        title += subrun["text"]
+                        if "twoColumnWatchNextResults" in ytdata["contents"]:
+                            morevInfo = ytdata["contents"]["twoColumnWatchNextResults"]["results"]["results"]["contents"][0]["videoPrimaryInfoRenderer"]
+                            if "viewCount" in morevInfo:
+                                videoInfo = morevInfo["viewCount"]["videoViewCountRenderer"]
+                                vcText = ""
+                                for text in videoInfo["viewCount"]["runs"]:
+                                    vcText += text["text"]
+                                if videoInfo["isLive"] and ("watching now" in vcText):
+                                    title = ""
+                                    if len(morevInfo["title"]["runs"]) > 1:
+                                        for subrun in morevInfo["title"]["runs"]:
+                                            title += subrun["text"]
+                                    else:
+                                        title = morevInfo["title"]["runs"][0]["text"]
+                                    output = {
+                                        "isLive": True,
+                                        "videoId": morevInfo["updatedMetadataEndpoint"]["updatedMetadataEndpoint"]["videoId"],
+                                        "videoTitle": title,
+                                        "timeText": morevInfo["dateText"]["simpleText"].replace('Started streaming ', '')
+                                    }
                                 else:
-                                    title = morevInfo["title"]["runs"][0]["text"]
-                                output = {
-                                    "isLive": True,
-                                    "videoId": morevInfo["updatedMetadataEndpoint"]["updatedMetadataEndpoint"]["videoId"],
-                                    "videoTitle": title,
-                                    "timeText": morevInfo["dateText"]["simpleText"].replace('Started streaming ', '')
-                                }
-                            else:
-                                output = {
-                                    "isLive": False
-                                }
+                                    output = {
+                                        "isLive": False
+                                    }
     if not output:
         output = {
             "isLive": False

--- a/ext/infoscraper.py
+++ b/ext/infoscraper.py
@@ -14,8 +14,12 @@ def round_down(num, divisor):
 
 async def streamInfo(channelId: Union[str, int]):
     output = None
+    checked = False
 
     for retryCount in range(3):
+        if checked:
+            break
+
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(f'https://www.youtube.com/channel/{channelId}/live?hl=en-US') as r:
@@ -51,10 +55,12 @@ async def streamInfo(channelId: Union[str, int]):
                                                 "videoTitle": title,
                                                 "timeText": morevInfo["dateText"]["simpleText"].replace('Started streaming ', '')
                                             }
+                                            checked = True
                                         else:
                                             output = {
                                                 "isLive": False
                                             }
+                                            checked = True
         except Exception as e:
             if retryCount > 1:
                 logging.error("Stream - An error has occured while getting stream info!", exc_info=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ imgkit == 1.0.2
 requests == 2.25.1
 pytz == 2020.5
 rpyc == 5.0.1
+dblpy == 0.4.0

--- a/setup/settings.yaml
+++ b/setup/settings.yaml
@@ -5,3 +5,5 @@ notify: True
 milestone: True
 thumbnailIP:
 thumbnailPort:
+dblPublish: False
+dblToken:


### PR DESCRIPTION
Since we now depend on our own image self-hosting, the bot is now prone to the reliability of the thumbnail server. With the thumbnail server sometimes not giving an error sometimes, it soft-locks the check on both livestreams and milestones, rendering the bot unusable/useless.

The fix has been tested for multiple days and will be merged instantly if no checks fail on CodeFactor's side.